### PR TITLE
Fix invoice download URL

### DIFF
--- a/templated_email/compiled/send_invoice.html
+++ b/templated_email/compiled/send_invoice.html
@@ -98,7 +98,7 @@
               <tr>
                 <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><a href="{{download_url}}">
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><a href="{{invoice.download_url}}">
             {{invoice.download_url}}
           </a></div>
     

--- a/templated_email/source/send_invoice.mjml
+++ b/templated_email/source/send_invoice.mjml
@@ -13,7 +13,7 @@
             In order to download invoice {{number}}, click the link below.
         </mj-text>
         <mj-text>
-          <a href="{{download_url}}">
+          <a href="{{invoice.download_url}}">
             {{invoice.download_url}}
           </a>
         </mj-text>


### PR DESCRIPTION
Invoice email template contains an empty link instead of the invoice link, even though it is displayed as a clickable link.
This change fixes that empty link, making it possible to click and get the invoice PDF, as it was intended.